### PR TITLE
Use AWS token to poll spot instance-action

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,10 @@ then
 ```bash
 git clone https://github.com/ben-kenney/aws-interrupt-monitor.git && cp .env aws-interrupt-monitor/ && cd aws-interrupt-monitor && VM_HOSTNAME=$(hostname) docker compose up -d
 ```
+
+## Build instructions:
+
+```
+docker build -t bak7/aws-interrupt-monitor .
+docker push bak7/aws-interrupt-monitor:latest
+```


### PR DESCRIPTION
Polling instance action from: http://169.254.169.254/latest/meta-data/spot/instance-action requires a token in the header. This update fetches the token then inserts it into the header.